### PR TITLE
Fixed classpath and imports 

### DIFF
--- a/dev/language_workbench_concurrency/org.gemoc.arduino.concurrent.k3dsa/META-INF/MANIFEST.MF
+++ b/dev/language_workbench_concurrency/org.gemoc.arduino.concurrent.k3dsa/META-INF/MANIFEST.MF
@@ -5,8 +5,7 @@ Bundle-SymbolicName: org.gemoc.arduino.concurrent.k3dsa
 Bundle-Version: 1.0.0.qualifier
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.xtend.lib;bundle-version="2.6.0";visibility:=private,
- fr.inria.diverse.k3.al.annotationprocessor.plugin;bundle-version="1.0.0",
- fr.obeo.dsl.debug.ide,
+ fr.inria.diverse.k3.al.annotationprocessor.plugin;bundle-version="1.0.0", 
  org.eclipse.xtend.core;bundle-version="2.7.3",
  org.eclipse.emf.ecore,
  org.eclipse.core.resources;bundle-version="3.9.1",
@@ -17,5 +16,6 @@ Require-Bundle: org.eclipse.core.runtime,
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Export-Package: org.gemoc.arduino.concurrent.k3dsa
-Import-Package: org.gemoc.execution.concurrent.ccsljavaengine.ui.launcher,
- org.gemoc.executionframework.engine.ui.launcher
+Import-Package: org.eclipse.gemoc.execution.concurrent.ccsljavaengine.ui.launcher,
+ org.eclipse.gemoc.executionframework.engine.ui.launcher
+ 

--- a/dev/language_workbench_concurrency/org.gemoc.arduino.concurrent.xarduino.design/META-INF/MANIFEST.MF
+++ b/dev/language_workbench_concurrency/org.gemoc.arduino.concurrent.xarduino.design/META-INF/MANIFEST.MF
@@ -15,12 +15,13 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.sirius.common;bundle-version="2.0.0",
  org.eclipse.sirius.common.ui;bundle-version="2.0.0",
  org.eclipse.sirius.diagram;bundle-version="2.0.0",
- org.gemoc.executionframework.extensions.sirius;bundle-version="0.1.0",
- org.gemoc.executionframework.engine.ui;bundle-version="0.1.0",
- org.gemoc.arduino.concurrent.xarduino;bundle-version="0.1.0",
- org.gemoc.execution.concurrent.ccsljavaengine.ui;bundle-version="0.1.0"
+ org.eclipse.gemoc.executionframework.extensions.sirius;bundle-version="0.1.0",
+ org.eclipse.gemoc.executionframework.engine.ui;bundle-version="0.1.0",
+ org.gemoc.arduino.concurrent.xarduino;bundle-version="0.1.0", 
+ org.eclipse.gemoc.execution.concurrent.ccsljavaengine.ui;bundle-version="2.3.0"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: com.google.common.collect
+Import-Package: com.google.common.collect,
+ org.eclipse.gemoc.executionframework.extensions.sirius.services
 Export-Package: org.gemoc.arduino.concurrent.xarduino.design,
  org.gemoc.arduino.concurrent.xarduino.design.services

--- a/dev/language_workbench_concurrency/org.gemoc.arduino.concurrent.xarduino.design/src/org/gemoc/arduino/concurrent/xarduino/design/services/ArduinoAnimatorServices.java
+++ b/dev/language_workbench_concurrency/org.gemoc.arduino.concurrent.xarduino.design/src/org/gemoc/arduino/concurrent/xarduino/design/services/ArduinoAnimatorServices.java
@@ -3,9 +3,10 @@ package org.gemoc.arduino.concurrent.xarduino.design.services;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.gemoc.executionframework.extensions.sirius.services.AbstractGemocAnimatorServices;
+import org.eclipse.gemoc.executionframework.extensions.sirius.services.AbstractGemocAnimatorServices;
 
-public class ArduinoAnimatorServices extends AbstractGemocAnimatorServices{
+
+public class ArduinoAnimatorServices extends AbstractGemocAnimatorServices {
 	
 	@Override
 	protected List<StringCouple> getRepresentationRefreshList() {

--- a/dev/language_workbench_concurrency/org.gemoc.arduino.concurrent.xarduino.design/src/org/gemoc/arduino/concurrent/xarduino/design/services/ArduinoDebuggerServices.java
+++ b/dev/language_workbench_concurrency/org.gemoc.arduino.concurrent.xarduino.design/src/org/gemoc/arduino/concurrent/xarduino/design/services/ArduinoDebuggerServices.java
@@ -5,13 +5,12 @@ import java.util.List;
 
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.gemoc.executionframework.extensions.sirius.services.AbstractGemocDebuggerServices;
 import org.gemoc.arduino.concurrent.xarduino.arduino.Board;
 import org.gemoc.arduino.concurrent.xarduino.arduino.Module;
 import org.gemoc.arduino.concurrent.xarduino.arduino.Pin;
 import org.gemoc.arduino.concurrent.xarduino.arduino.Project;
 import org.gemoc.arduino.concurrent.xarduino.design.ArduinoDesignerUtils;
-import org.gemoc.executionframework.extensions.sirius.services.AbstractGemocDebuggerServices;
-
 
 public class ArduinoDebuggerServices extends AbstractGemocDebuggerServices{
 
@@ -52,7 +51,7 @@ public class ArduinoDebuggerServices extends AbstractGemocDebuggerServices{
 		return ArduinoDesignerUtils.getPin(module).getLevel() > 0;
 	}
 	
-	public String getModelIdentifier() {
-		return org.gemoc.execution.concurrent.ccsljavaengine.ui.Activator.PLUGIN_ID+".debugModel";
+	public String getModelIdentifier() {		
+		return org.eclipse.gemoc.execution.concurrent.ccsljavaengine.ui.Activator.PLUGIN_ID+".debugModel";
 	}
 }

--- a/dev/language_workbench_sequential/org.gemoc.arduino.sequential.xarduino.design/src/org/gemoc/arduino/sequential/xardunio/design/services/ArduinoServices.java
+++ b/dev/language_workbench_sequential/org.gemoc.arduino.sequential.xarduino.design/src/org/gemoc/arduino/sequential/xardunio/design/services/ArduinoServices.java
@@ -51,6 +51,7 @@ import org.gemoc.arduino.sequential.xarduino.arduino.Block;
 import org.gemoc.arduino.sequential.xarduino.arduino.BluetoothTransceiver;
 import org.gemoc.arduino.sequential.xarduino.arduino.Board;
 import org.gemoc.arduino.sequential.xarduino.arduino.BooleanConstant;
+import org.gemoc.arduino.sequential.xarduino.arduino.BooleanExpression;
 import org.gemoc.arduino.sequential.xarduino.arduino.BooleanModuleGet;
 import org.gemoc.arduino.sequential.xarduino.arduino.BooleanVariable;
 import org.gemoc.arduino.sequential.xarduino.arduino.BooleanVariableRef;
@@ -95,7 +96,7 @@ import org.gemoc.arduino.sequential.xarduino.design.ArduinoDesignerUtils;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
-import javafx.beans.binding.BooleanExpression;
+
 
 public class ArduinoServices {
 	


### PR DESCRIPTION
Hi,
I noticed a couple of import errors in the arduino modeling project.
Most common one was the missing `eclipse` namespace in several package imports.
Now the project builds fluently in the latest version of gemoc.
